### PR TITLE
fix copyright field: overwrites description

### DIFF
--- a/src/mrss_parser.c
+++ b/src/mrss_parser.c
@@ -330,8 +330,8 @@ static void __mrss_parser_atom_entry(nxml_t *doc, nxml_data_t *cur,
 
       /* right -> copyright */
       else if (!item->copyright && !strcmp(cur->value, "rights"))
-        __mrss_parser_atom_string(doc, cur, &item->description,
-                                  &item->description_type);
+        __mrss_parser_atom_string(doc, cur, &item->copyright,
+                                  &item->copyright_type);
 
       /* author structure -> author elements */
       else if (!strcmp(cur->value, "author"))


### PR DESCRIPTION
I honestly don't think this field is used by anyone in the universe, yet I'm almost certain this is a bug.

I think that a unit test would be beneficial.