### PR TITLE
Forward patches by Debian contributors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,3 +4,5 @@ EXTRA_DIST = mrss.pc mrss.pc.in doxy.conf doxy.conf.in
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = mrss.pc
+
+ACLOCAL_AMFLAGS=-I m4

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_INIT([libmrss], [libmrss_version])
 AC_CONFIG_SRCDIR([src/mrss_generic.c])
 AC_CONFIG_MACRO_DIRS([m4])
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 AM_SANITY_CHECK
 AM_CONFIG_HEADER(config.h)
 AM_MAINTAINER_MODE

--- a/mrss.pc.in
+++ b/mrss.pc.in
@@ -1,6 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+exec_prefix=@exec_prefix@
+libdir=@libdir@
 includedir=@includedir@
 
 Name: libmrss

--- a/src/mrss_parser.c
+++ b/src/mrss_parser.c
@@ -316,7 +316,16 @@ static void __mrss_parser_atom_entry(nxml_t *doc, nxml_data_t *cur,
       /* link href -> link */
       else if (!item->link && !strcmp(cur->value, "link") &&
                (c = nxmle_find_attribute(cur, "href", NULL)))
-        item->link = c;
+	    {
+		char *t;
+
+		/* alternate link is either rel="alternate" or a link tag
+		 * without a rel attribute
+		 */
+		t = nxmle_find_attribute (cur, "rel", NULL);
+		if ((t && !strcmp(t, "alternate")) || !t)
+		  item->link = c;
+	    }
 
       /* content -> description */
       else if (!item->description && !strcmp(cur->value, "content"))


### PR DESCRIPTION
* atom-link.diff: Fixes wrong <link> parsed in Atom feeds by Debian QA Group.
* multiarchify_pc_file.patch: Updates mrss.pc.in to support multiarch by Joseph Herlant.
* cleanup_configure_warnings.patch: Removes libtools and automake warnings by Joseph Herlant.